### PR TITLE
fix ios linking issue on, add missing Frameworks

### DIFF
--- a/Laerdal.FFmpeg/Laerdal.FFmpeg.csproj
+++ b/Laerdal.FFmpeg/Laerdal.FFmpeg.csproj
@@ -117,7 +117,7 @@
             <Kind>Framework</Kind>
             <SmartLink>True</SmartLink>
             <ForceLoad>True</ForceLoad>
-            <Frameworks>AudioToolbox VideoToolbox CoreVideo</Frameworks>
+            <Frameworks>AudioToolbox VideoToolbox CoreVideo CoreMedia</Frameworks>
         </NativeReference>
 
         <!-- iOS\Frameworks\libavutil.framework -->
@@ -129,7 +129,7 @@
             <Kind>Framework</Kind>
             <SmartLink>True</SmartLink>
             <ForceLoad>True</ForceLoad>
-            <Frameworks>VideoToolbox CoreVideo</Frameworks>
+            <Frameworks>VideoToolbox CoreVideo CoreMedia</Frameworks>
         </NativeReference>
 
         <!-- iOS\Frameworks\mobileffmpeg.framework -->


### PR DESCRIPTION
if you try to build and nuget, and then run app with that nuget on iOS - you will face with linking issues.

that PR fixing missing Frameworks for correct linking